### PR TITLE
Fix for unexpected error in cloudwatch logs. Checking for empty unzipped content and returning empty obj with empt…

### DIFF
--- a/src/aws_cloud_trail_listener.js
+++ b/src/aws_cloud_trail_listener.js
@@ -98,7 +98,8 @@ class AwsCloudTrailListener {
         if (err) {
           reject(err);
         } else {
-          resolve(JSON.parse(result.toString()));
+          const unzippedLog = result.toString() ? JSON.parse(result.toString()) : { Records: [] };
+          resolve(unzippedLog);
         }
       });
     });


### PR DESCRIPTION
…y records array or the parsed result