### PR TITLE
Reduced the AutoTagExecutionPolicy to allow s3:GetObject only in the …

### DIFF
--- a/cloud_formation/template.json
+++ b/cloud_formation/template.json
@@ -135,7 +135,8 @@
                 "s3:ListBucket"
               ],
               "Resource": [
-                "*"
+                { "Fn::Join": [ "", [ "arn:aws:s3:::", { "Ref" : "CloudTrailBucketName" } ] ] },
+                { "Fn::Join": [ "", [ "arn:aws:s3:::", { "Ref" : "CloudTrailBucketName" }, "/*" ] ] }
               ]
             },
             {


### PR DESCRIPTION
Hi,

  I reduced the AutoTagExecutionPolicy to allow s3:GetObject only in the CloudTrail bucket.

Thanks for writing this!

Ray