### PR TITLE
Stopped processing CloudTrail events that contain errorCode and errorMessage

### DIFF
--- a/src/aws_cloud_trail_listener.js
+++ b/src/aws_cloud_trail_listener.js
@@ -62,9 +62,11 @@ class AwsCloudTrailListener {
         let log = yield _this.retrieveAndUnGzipLog(logFiles[i]);
         for (let j in log.Records) {
           let event = log.Records[j];
-          let worker = AutotagFactory.createWorker(event, _this.enabledServices, _this.s3Region);
-          yield worker.tagResource();
-        }
+	  if (!event.errorCode && !event.errorMessage) {
+	    let worker = AutotagFactory.createWorker(event, _this.enabledServices, _this.s3Region);
+	    yield worker.tagResource();
+	  }
+	}
       }
     });
   }
@@ -116,7 +118,7 @@ const dumpRecord = (event) => {
   console.log('Request Parameters:');
   console.log(event.requestParameters);
   console.log('Response Elements:');
-  console.log(event.requestParameters);
+  console.log(event.responseElements);
   console.log('s3:');
   console.log(event.s3);
 };


### PR DESCRIPTION
I found that some error message payloads were being sent to the workers but were failing. This was also observed by issue https://github.com/GorillaStack/auto-tag/issues/4.

Error:
```
{
    "errorMessage": "Cannot read property 'instancesSet' of null",
    "errorType": "TypeError",
    "stackTrace": [
        "AutotagEC2Worker.getInstanceId (/var/task/workers/autotag_ec2_worker.js:105:41)",
        "_callee$ (/var/task/workers/autotag_ec2_worker.js:71:53)",
        "tryCatch (/var/task/node_modules/regenerator-runtime/runtime.js:65:40)",
        "GeneratorFunctionPrototype.invoke [as _invoke] (/var/task/node_modules/regenerator-runtime/runtime.js:303:22)",
        "GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/var/task/node_modules/regenerator-runtime/runtime.js:117:21)",
        "onFulfilled (/var/task/node_modules/co/index.js:65:19)",
        "run (/var/task/node_modules/core-js/modules/es6.promise.js:66:22)",
        "/var/task/node_modules/core-js/modules/es6.promise.js:79:30",
        "flush (/var/task/node_modules/core-js/modules/_microtask.js:18:9)",
        "nextTickCallbackWith0Args (node.js:415:9)"
    ]
}
```

This error was a result of a CloudTrail error message like this one where `responseElements` is null:
```
{
    "eventVersion": "1.05",
    "userIdentity": {
        "type": "Root",
        "principalId": "111111111",
        "arn": "arn:aws:iam::1111111:root",
        "accountId": "1111111111",
        "userName": "xxxx",
        "invokedBy": "autoscaling.amazonaws.com"
    },
    "eventTime": "2017-12-06T22:15:46Z",
    "eventSource": "ec2.amazonaws.com",
    "eventName": "RunInstances",
    "awsRegion": "us-west-2",
    "sourceIPAddress": "autoscaling.amazonaws.com",
    "userAgent": "autoscaling.amazonaws.com",
    "errorCode": "Client.AuthFailure",
    "errorMessage": "Not authorized for images: [ami-xxxxxxx]",
    "requestParameters": {
        "instancesSet": {
            "items": [
                {
                    "imageId": "ami-xxxxxx",
                    "minCount": 1,
                    "maxCount": 1,
                    "keyName": "Server1"
                }
            ]
        },
        "groupSet": {
            "items": [
                {
                    "groupName": "AAAA-SBAASecurityGroup-AAAAA"
                }
            ]
        },
        "userData": "<sensitiveDataRemoved>",
        "instanceType": "t1.micro",
        "blockDeviceMapping": {},
        "availabilityZone": "us-west-2b",
        "monitoring": {
            "enabled": true
        },
        "disableApiTermination": false,
        "clientToken": ""
    },
    "responseElements": null,
    "requestID": "ffe5a93b-cfc5-43a3-bbaf-AAAAAAA",
    "eventID": "b657f731-606a-4a0c-b21e-AAAAAAA",
    "eventType": "AwsApiCall",
    "recipientAccountId": "11111111"
}
```

