### PR TITLE
Hardcoding the name to be AutoTag for the function name as there are …

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ __CloudFormation Main Stack__ Deploy this stack first in a single "master" regio
 1. Click the CloudFormation drop-down button and select "Stack"
 1. Click the blue "Create Stack" button
 1. Select "Upload a template to Amazon S3", choosing the `autotag_event_main-template.json` that was created in the ruby template builder step, then click the blue "Next" button
-1. Name the stack "AutoTag" - this cannot be changed
+1. Name the stack "AutoTag" - this name can be anything
 1. In the parameter section:
 * CodeS3Bucket: The name of the code bucket in S3
 * CodeS3Path: This is the version of AutoTag that you wish to deploy.  The default value `autotag-0.3.0.zip` is the latest version

--- a/cloud_formation/event_multi_region_template/autotag_event_main-template.rb
+++ b/cloud_formation/event_multi_region_template/autotag_event_main-template.rb
@@ -52,7 +52,7 @@ template do
       S3Key: ref('CodeS3Path'),
     },
     Description: 'Auto Tag (Open Source by GorillaStack)',
-    FunctionName: aws_stack_name,
+    FunctionName: 'AutoTag',
     Handler: sub('autotag_event.handler'),
     Role: get_att('AutoTagExecutionRole', 'Arn'),
     Runtime: 'nodejs6.10',


### PR DESCRIPTION
…collector template has its hardcoded.
Also, Readme tells that the name of the stack does not matter - which is not true due to this.

such as 
https://github.com/GorillaStack/auto-tag/blob/8746e110e9461be70b7eb09cfd37b1cb2ef6d360/cloud_formation/event_multi_region_template/autotag_event_collector-template.json#L116

This will fix #46