### PR TITLE
remove duplicate function call

### DIFF
--- a/src/workers/autotag_s3_worker.js
+++ b/src/workers/autotag_s3_worker.js
@@ -50,7 +50,7 @@ class AutotagS3Worker extends AutotagDefaultWorker {
         const bucketName = this.getBucketName();
         this.logTags(bucketName, tags, this.constructor.name);
         this.s3.putBucketTagging({
-          Bucket: this.getBucketName(),
+          Bucket: bucketName,
           Tagging: {
             TagSet: tags
           }


### PR DESCRIPTION
On [line 50](https://github.com/GorillaStack/auto-tag/compare/master...hiimbex:patch-1#diff-080d5598b0415cc477372e85884217a7L50) we do `const bucketName = this.getBucketName();`, so no need to get the bucket name again :)