### PR TITLE
Fix issue #91

### DIFF
--- a/deploy_autotag.sh
+++ b/deploy_autotag.sh
@@ -207,7 +207,7 @@ function cf-parameters () {
       },
       {
         "ParameterKey": "CustomTags",
-        "ParameterValue": "${CUSTOM_TAGS//\"/\\\"}"
+        "ParameterValue": "${CUSTOM_TAGS//\"/\"}"
       }
     ]
 EOF


### PR DESCRIPTION
Fixes issue where Custom Tags Can't be parsed by jq in the cfparameters function when merging parameters with the MAIN CF Template and the custom parameter has a JSON value populated.