### PR TITLE
Lambda user agent

### DIFF
--- a/cloud_formation/event_multi_region_template/autotag_event_main-template.json
+++ b/cloud_formation/event_multi_region_template/autotag_event_main-template.json
@@ -82,7 +82,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 120,
         "Environment": {
           "Variables": {

--- a/src/workers/autotag_default_worker.js
+++ b/src/workers/autotag_default_worker.js
@@ -172,7 +172,11 @@ class AutotagDefaultWorker {
           console.log(`WARN: Failed to perform the variable substitution for ${tagValueVariable}`);
         }
         // replace the variable in the tag value with the associated event value
-        newTagValue = newTagValue.replace(tagValueVariable, tagValueVariableReplacement);
+        if (tagValueVariable.toLowerCase().includes('useragent')) {
+          newTagValue = newTagValue.replace(tagValueVariable, tagValueVariableReplacement).replace(/\(/g,"--").replace(/\)/g,"--").replace(/\[/g,"--").replace(/\]/g,"--").replace(/\{/g,"--").replace(/\}/g,"--").replace(/\,/g,":").replace(/\;/g,":").replace(/\ /g,"_");
+        } else {
+          newTagValue = newTagValue.replace(tagValueVariable, tagValueVariableReplacement);
+      }
       });
       // if all of the variable substitutions in the tag value have failed drop the entire tag
       if (tagValueVariables.length > 0 && tagValueVariables.length === (newTagValue.match(/undefined/g) || []).length) {

--- a/src/workers/autotag_lambda_function_worker.js
+++ b/src/workers/autotag_lambda_function_worker.js
@@ -43,11 +43,7 @@ class AutotagLambdaFunctionWorker extends AutotagDefaultWorker {
   getFunctionTags(tags) {
     const newTags = {};
     tags.forEach(tag => {
-      if (tag.Key.toLowerCase().includes('useragent')){
-        newTags[tag.Key] = tag.Value.replace(/\(/g,"/").replace(/\)/g,"/").replace(/\,/g,":").replace(/\;/g,":").replace(/\ /g,"_");
-      } else {
-        newTags[tag.Key] = tag.Value;
-      }     
+      newTags[tag.Key] = tag.Value;
     });
     return newTags;
   }

--- a/src/workers/autotag_lambda_function_worker.js
+++ b/src/workers/autotag_lambda_function_worker.js
@@ -43,7 +43,11 @@ class AutotagLambdaFunctionWorker extends AutotagDefaultWorker {
   getFunctionTags(tags) {
     const newTags = {};
     tags.forEach(tag => {
-      newTags[tag.Key] = tag.Value;
+      if (tag.Key.toLowerCase().includes('useragent')){
+        newTags[tag.Key] = tag.Value.replace(/\(/g,"/").replace(/\)/g,"/").replace(/\,/g,":");
+      } else {
+        newTags[tag.Key] = tag.Value;
+      }     
     });
     return newTags;
   }

--- a/src/workers/autotag_lambda_function_worker.js
+++ b/src/workers/autotag_lambda_function_worker.js
@@ -44,7 +44,7 @@ class AutotagLambdaFunctionWorker extends AutotagDefaultWorker {
     const newTags = {};
     tags.forEach(tag => {
       if (tag.Key.toLowerCase().includes('useragent')){
-        newTags[tag.Key] = tag.Value.replace(/\(/g,"/").replace(/\)/g,"/").replace(/\,/g,":");
+        newTags[tag.Key] = tag.Value.replace(/\(/g,"/").replace(/\)/g,"/").replace(/\,/g,":").replace(/\;/g,":").replace(/\ /g,"_");
       } else {
         newTags[tag.Key] = tag.Value;
       }     


### PR DESCRIPTION
Two AWS API endpoints don't support User Agent Fields that come in the Cloud Trail events in their original format:

- AWS Lambda Itself (characters like comma, parenthesis, etc) are not supported by the Lambda Tagging API.
- AWS S3 (the braces [] characters are not supported by the API)

The following fix looks for the user agent fieldname in the default worker and replaces all possible invalid characters at the parent class level, rather than dealing with each worker, thus future workers can be added.