### PR TITLE
Multi stack support

### DIFF
--- a/cloud_formation/event_multi_region_template/autotag_event_collector-template.json
+++ b/cloud_formation/event_multi_region_template/autotag_event_collector-template.json
@@ -7,6 +7,11 @@
       "Description" : "The region where the main auto-tag CloudFormation stack is running",
       "Type" : "String",
       "Default": "us-west-2"
+    },
+    "MainTemplateName":{
+      "Description": "Name of the Main template that holds the Auto-Tagging Lambda Function this log collector template submits to",
+      "Type": "String",
+      "Default": "AutoTag"
     }
   },
 
@@ -127,7 +132,7 @@
     "AutoTagSNSSubscription": {
       "Type": "AWS::SNS::Subscription",
       "Properties": {
-        "Endpoint": { "Fn::Sub": "arn:aws:lambda:${MainAwsRegion}:${AWS::AccountId}:function:AutoTag" },
+        "Endpoint": { "Fn::Sub": "arn:aws:lambda:${MainAwsRegion}:${AWS::AccountId}:function:${MainTemplateName}" },
         "Protocol": "lambda",
         "TopicArn": {
           "Ref": "AutoTagSNSTopic"

--- a/cloud_formation/event_multi_region_template/autotag_event_collector-template.json
+++ b/cloud_formation/event_multi_region_template/autotag_event_collector-template.json
@@ -8,10 +8,14 @@
       "Type" : "String",
       "Default": "us-west-2"
     },
-    "MainTemplateName":{
-      "Description": "Name of the Main template that holds the Auto-Tagging Lambda Function this log collector template submits to",
+    "LambdaName": {
+      "Description": "The name of the Lambda Function of the Main Stack Set.",
       "Type": "String",
-      "Default": "AutoTag"
+      "Default": "AutoTag",
+      "AllowedValues":[
+        "AutoTag",
+        "AutoTagDev"
+      ]
     }
   },
 
@@ -132,7 +136,7 @@
     "AutoTagSNSSubscription": {
       "Type": "AWS::SNS::Subscription",
       "Properties": {
-        "Endpoint": { "Fn::Sub": "arn:aws:lambda:${MainAwsRegion}:${AWS::AccountId}:function:${MainTemplateName}" },
+        "Endpoint": { "Fn::Sub": "arn:aws:lambda:${MainAwsRegion}:${AWS::AccountId}:function:${LambdaName}" },
         "Protocol": "lambda",
         "TopicArn": {
           "Ref": "AutoTagSNSTopic"

--- a/cloud_formation/event_multi_region_template/autotag_event_collector-template.json
+++ b/cloud_formation/event_multi_region_template/autotag_event_collector-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Auto Tag (Open Source by GorillaStack)",
+  "Description": "Auto Tag Solution by Gorilla Stack - Deployed and Maintained by Guitar Center DevOps.",
 
   "Parameters" : {
     "MainAwsRegion" : {

--- a/cloud_formation/event_multi_region_template/autotag_event_collector-template.json
+++ b/cloud_formation/event_multi_region_template/autotag_event_collector-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Auto Tag Solution by Gorilla Stack - Deployed and Maintained by Guitar Center DevOps.",
+  "Description": "Auto Tag (Open Source by GorillaStack)",
 
   "Parameters" : {
     "MainAwsRegion" : {

--- a/cloud_formation/event_multi_region_template/autotag_event_main-template.json
+++ b/cloud_formation/event_multi_region_template/autotag_event_main-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Auto Tag (Open Source by GorillaStack)",
+  "Description": "Auto Tag Solution by Gorilla Stack - Deployed and Maintained by Guitar Center DevOps.",
   "Parameters": {
     "CodeS3Bucket": {
       "Description": "The name of the code bucket in S3.",
@@ -71,7 +71,7 @@
             "Ref": "CodeS3Path"
           }
         },
-        "Description": "Auto Tag (Open Source by GorillaStack)",
+        "Description": "Auto Tag Solution by Gorilla Stack - Deployed and Maintained by Guitar Center DevOps.",
         "FunctionName": {
           "Fn::Sub": "${AWS::StackName}"
         },

--- a/cloud_formation/event_multi_region_template/autotag_event_main-template.json
+++ b/cloud_formation/event_multi_region_template/autotag_event_main-template.json
@@ -10,7 +10,7 @@
     "CodeS3Path": {
       "Description": "The path of the code zip file in the code bucket in S3.",
       "Type": "String",
-      "Default": "autotag-0.5.0.zip"
+      "Default": "autotag-0.5.3.zip"
     },
     "AutoTagDebugLogging": {
       "Description": "Enable/Disable Debug Logging for the Lambda Function for all processed CloudTrail events.",
@@ -72,7 +72,9 @@
           }
         },
         "Description": "Auto Tag (Open Source by GorillaStack)",
-        "FunctionName": "AutoTag",
+        "FunctionName": {
+          "Fn::Sub": "${AWS::StackName}"
+        },
         "Handler": {
           "Fn::Sub": "autotag_event.handler"
         },

--- a/cloud_formation/event_multi_region_template/autotag_event_main-template.json
+++ b/cloud_formation/event_multi_region_template/autotag_event_main-template.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "Auto Tag Solution by Gorilla Stack - Deployed and Maintained by Guitar Center DevOps.",
+  "Description": "Auto Tag (Open Source by GorillaStack)",
   "Parameters": {
     "LambdaName": {
       "Description": "The name of the Lambda Function.",
@@ -80,7 +80,7 @@
             "Ref": "CodeS3Path"
           }
         },
-        "Description": "Auto Tag Solution by Gorilla Stack - Deployed and Maintained by Guitar Center DevOps.",
+        "Description": "Auto Tag (Open Source by GorillaStack)",
         "FunctionName": {
           "Fn::Sub": "${LambdaName}"
         },

--- a/cloud_formation/event_multi_region_template/autotag_event_main-template.json
+++ b/cloud_formation/event_multi_region_template/autotag_event_main-template.json
@@ -2,6 +2,15 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "Auto Tag Solution by Gorilla Stack - Deployed and Maintained by Guitar Center DevOps.",
   "Parameters": {
+    "LambdaName": {
+      "Description": "The name of the Lambda Function.",
+      "Type": "String",
+      "Default": "AutoTag",
+      "AllowedValues":[
+        "AutoTag",
+        "AutoTagDev"
+      ]
+    },
     "CodeS3Bucket": {
       "Description": "The name of the code bucket in S3.",
       "Type": "String",
@@ -73,7 +82,7 @@
         },
         "Description": "Auto Tag Solution by Gorilla Stack - Deployed and Maintained by Guitar Center DevOps.",
         "FunctionName": {
-          "Fn::Sub": "${AWS::StackName}"
+          "Fn::Sub": "${LambdaName}"
         },
         "Handler": {
           "Fn::Sub": "autotag_event.handler"

--- a/cloud_formation/event_multi_region_template/autotag_event_main-template.json
+++ b/cloud_formation/event_multi_region_template/autotag_event_main-template.json
@@ -93,7 +93,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs10.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 120,
         "Environment": {
           "Variables": {

--- a/cloud_formation/event_multi_region_template/autotag_event_main-template.rb
+++ b/cloud_formation/event_multi_region_template/autotag_event_main-template.rb
@@ -19,7 +19,13 @@ template do
   parameter 'CodeS3Path',
             Description: 'The path of the code zip file in the code bucket in S3.',
             Type: 'String',
-            Default: 'autotag-0.5.0.zip'
+            Default: 'autotag-0.5.3.zip'
+
+  parameter 'LambdaName',
+            Description: 'The name of the Lambda Function.',
+            Type: 'String',
+            AllowedValues: %w(AutoTag AutoTagDev),
+            Default: 'AutoTag'
 
   parameter 'AutoTagDebugLogging',
             Description: 'Enable/Disable Debug Logging for the Lambda Function for all processed CloudTrail events.',
@@ -61,7 +67,7 @@ template do
       S3Key: ref('CodeS3Path'),
     },
     Description: 'Auto Tag (Open Source by GorillaStack)',
-    FunctionName: 'AutoTag',
+    FunctionName: sub('${LambdaName}'),
     Handler: sub('autotag_event.handler'),
     Role: get_att('AutoTagExecutionRole', 'Arn'),
     Runtime: 'nodejs10.x',

--- a/cloud_formation/event_single_region_template/autotag_event-template.json
+++ b/cloud_formation/event_single_region_template/autotag_event-template.json
@@ -12,7 +12,7 @@
     "CodeS3Path" : {
       "Description" : "The path of the code zip file in the code bucket in S3",
       "Type" : "String",
-      "Default" : "autotag-0.5.0.zip"
+      "Default" : "autotag-0.5.3.zip"
     },
     "AutoTagDebugLogging": {
       "Description": "Enable/Disable Debug Logging for the Lambda Function for all processed CloudTrail events.",
@@ -62,7 +62,9 @@
           "S3Key": { "Ref" : "CodeS3Path" }
         },
         "Description" : "Auto Tag (Open Source by GorillaStack)",
-        "FunctionName" : "AutoTag",
+        "FunctionName" : {
+          "Fn::Sub": "${AWS::StackName}"
+        },
         "Handler" : "autotag_event.handler",
         "Role" : { "Fn::GetAtt" : [ "AutoTagExecutionRole", "Arn" ] },
         "Runtime" : "nodejs10.x",


### PR DESCRIPTION
This allows to have multiple Cloud Formation STACK SETS with Service Managed Roles in Cloud Formation supporting Multiple Environments. Using Stack Sets we can deploy to multiple account bundles using Organizational Units(OUs), i.e., one for Dev and one for Prod. 
 Instead of being fixed as AutoTag, the Lambda Function's name is taken from a Parameter in the Main Stack and that same Parameter is used in the multi-region Notification Stack to feed the SNS topic.
Thus you can have an AutoTag and AutoTagDev Lambda function running on the same region and under the same account if necessary, but most importantly you can separate them by environment name at the Stack Set level under your Parent AWS Account. 

Thanks!