### PR TITLE
Bump Node version to 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "12"
+  - "14"
 install:
   # Install deps
   - npm install

--- a/babelrc-node.js
+++ b/babelrc-node.js
@@ -1,7 +1,7 @@
 module.exports = {
   "presets": [["@babel/preset-env", {
     "targets": {
-      "node": "12"
+      "node": "14"
     }
   }]],
   "env": {}

--- a/cloud_formation/event_multi_region_template/autotag_event_main-template.json
+++ b/cloud_formation/event_multi_region_template/autotag_event_main-template.json
@@ -82,7 +82,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 120,
         "Environment": {
           "Variables": {

--- a/cloud_formation/event_multi_region_template/autotag_event_main-template.rb
+++ b/cloud_formation/event_multi_region_template/autotag_event_main-template.rb
@@ -64,7 +64,7 @@ template do
     FunctionName: 'AutoTag',
     Handler: sub('autotag_event.handler'),
     Role: get_att('AutoTagExecutionRole', 'Arn'),
-    Runtime: 'nodejs12.x',
+    Runtime: 'nodejs14.x',
     # the ec2 instance worker will wait for up to 45 seconds for a
     # opsworks stack or autoscaling group to be tagged with the creator
     # in case the events come out of order

--- a/cloud_formation/event_single_region_template/autotag_event-template.json
+++ b/cloud_formation/event_single_region_template/autotag_event-template.json
@@ -65,7 +65,7 @@
         "FunctionName" : "AutoTag",
         "Handler" : "autotag_event.handler",
         "Role" : { "Fn::GetAtt" : [ "AutoTagExecutionRole", "Arn" ] },
-        "Runtime" : "nodejs12.x",
+        "Runtime" : "nodejs14.x",
         "Timeout" : 120,
         "Environment": {
           "Variables": {


### PR DESCRIPTION
Creating this PR is probably not necessary as is fixing the actual release artifacts to contains the updated cloud formation templates to use `Node12.x` runtime so that the `deploy_autotag.sh` can work successfully as is. 
Nevertheless  the recommendation from AWS is to use the latest runtime and hence creating this to mitigate the issue (provided a release artifact is created)
https://github.com/GorillaStack/auto-tag/issues/101
