### PR TITLE
chore: bump lambda runtime to node18.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "14"
+  - "18"
 install:
   # Install deps
   - npm install

--- a/babelrc-node.js
+++ b/babelrc-node.js
@@ -1,8 +1,8 @@
 module.exports = {
-  "presets": [["@babel/preset-env", {
-    "targets": {
-      "node": "14"
+  presets: [['@babel/preset-env', {
+    targets: {
+      node: '18'
     }
   }]],
-  "env": {}
+  env: {}
 };

--- a/cloud_formation/event_multi_region_template/autotag_event_main-template.json
+++ b/cloud_formation/event_multi_region_template/autotag_event_main-template.json
@@ -93,7 +93,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 120,
         "Environment": {
           "Variables": {

--- a/cloud_formation/event_multi_region_template/autotag_event_main-template.rb
+++ b/cloud_formation/event_multi_region_template/autotag_event_main-template.rb
@@ -70,7 +70,7 @@ template do
     FunctionName: sub('${LambdaName}'),
     Handler: sub('autotag_event.handler'),
     Role: get_att('AutoTagExecutionRole', 'Arn'),
-    Runtime: 'nodejs14.x',
+    Runtime: 'nodejs18.x',
     # the ec2 instance worker will wait for up to 45 seconds for a
     # opsworks stack or autoscaling group to be tagged with the creator
     # in case the events come out of order

--- a/cloud_formation/event_single_region_template/autotag_event-template.json
+++ b/cloud_formation/event_single_region_template/autotag_event-template.json
@@ -67,7 +67,7 @@
         },
         "Handler" : "autotag_event.handler",
         "Role" : { "Fn::GetAtt" : [ "AutoTagExecutionRole", "Arn" ] },
-        "Runtime" : "nodejs14.x",
+        "Runtime" : "nodejs18.x",
         "Timeout" : 120,
         "Environment": {
           "Variables": {

--- a/spec/autotag_spec.js
+++ b/spec/autotag_spec.js
@@ -21,8 +21,11 @@ each(cloudTrailEventConfig, (value, key) => {
 
 describe('AutoTag index file', () => {
   beforeAll(() => {
-    requireMock('../src/aws_cloud_trail_event_listener', AwsCloudTrailListenerMock);
-    sut = require('../src/autotag_event.js'); // eslint-disable-line global-require
+    requireMock(
+      '../src/aws_cloud_trail_event_listener',
+      AwsCloudTrailListenerMock
+    );
+    sut = require('../src/autotag_event'); // eslint-disable-line global-require
   });
 
   afterAll(() => {


### PR DESCRIPTION
Updating Auto Tag to Node 18 (LTS) which is the latest recommended AWS runtime. Also fixed some lint errors.