### PR TITLE
bugFix/add in streaming changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "private": true,
   "dependencies": {
     "babel-polyfill": "^6.7.4",
-    "lodash": "^4.17.14"
+    "lodash": "^4.17.14",
+    "zlib": "^1.0.5"
   },
   "optionalDependencies": {
     "@aws-sdk/client-auto-scaling": "^3.410.0",


### PR DESCRIPTION
With the recent updates to the @aws-sdk/client-s3 package, the returned object from the `getObejct` call is not a Buffer but a `Readable` stream instead (https://github.com/aws/aws-sdk-js-v3/issues/1877).

This PR modifies adds `zlib` as an explicit dependency (as during testing it was not being added to the list of `node_modules`), changes the import format to just `zlib` instead of `zlib.js` and also adds functionality to piece together the string object from `getObject` before it is passed to `gunzip`. These changes should fix the existing issues with the retro tagging functionality.